### PR TITLE
chore: add basedpyright baseline and CI type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Ruff lint
         run: uv run ruff check .
 
+      - name: Basedpyright
+        run: uv run basedpyright
+
       - name: Prune uv cache
         if: always()
         run: uv cache prune --ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ uv run pre-commit run --all-files
 
 - Format: `uv run ruff format .`
 - Lint: `uv run ruff check .`
+- Types: `uv run basedpyright`
 - Tests (fast, default): `uv run pytest`
 - Coverage: `uv run pytest --cov=exp_harness --cov-report=term-missing`
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Common commands:
 ```bash
 uv run ruff format .
 uv run ruff check . --fix
+uv run basedpyright
 uv run pytest
 uv run pytest --cov=exp_harness --cov-report=term-missing
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,13 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pre-commit>=3.7", "pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6.0"]
+dev = [
+  "basedpyright>=1.31.0",
+  "pre-commit>=3.7",
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+  "ruff>=0.6.0",
+]
 
 [project.scripts]
 run-experiment = "exp_harness.cli:app"
@@ -53,3 +59,9 @@ ignore = [
   "ARG002", # test doubles / protocol-style methods
   "ARG005", # lambdas used for monkeypatch
 ]
+
+[tool.basedpyright]
+pythonVersion = "3.12"
+typeCheckingMode = "basic"
+include = ["src", "tests"]
+reportMissingTypeStubs = "none"

--- a/src/exp_harness/executors/__init__.py
+++ b/src/exp_harness/executors/__init__.py
@@ -1,1 +1,3 @@
+from . import base, docker, local
+
 __all__ = ["base", "docker", "local"]

--- a/src/exp_harness/executors/docker.py
+++ b/src/exp_harness/executors/docker.py
@@ -9,7 +9,7 @@ import time
 from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol, cast
 
 from exp_harness.docker_utils import inspect_image
 from exp_harness.executors.base import RunContext, StepResult
@@ -448,9 +448,9 @@ class DockerExecutor:
                 continue
 
             for key, _ in events:
-                stream_name, file_fp, live_fp = key.data
+                _, file_fp, live_fp = key.data
                 try:
-                    chunk = os.read(key.fileobj.fileno(), 64 * 1024)
+                    chunk = os.read(_selector_fd(key.fileobj), 64 * 1024)
                 except Exception:
                     chunk = b""
                 if not chunk:
@@ -477,3 +477,15 @@ class DockerExecutor:
 
     def docker_metadata(self) -> dict[str, Any]:
         return self._image_meta or {}
+
+
+def _selector_fd(fileobj: object) -> int:
+    if isinstance(fileobj, int):
+        return fileobj
+    if hasattr(fileobj, "fileno"):
+        return cast(_HasFileno, fileobj).fileno()
+    raise TypeError("Selector file object does not provide fileno()")
+
+
+class _HasFileno(Protocol):
+    def fileno(self) -> int: ...

--- a/src/exp_harness/executors/local.py
+++ b/src/exp_harness/executors/local.py
@@ -8,6 +8,7 @@ import sys
 import time
 from contextlib import suppress
 from pathlib import Path
+from typing import Protocol, cast
 
 from exp_harness.executors.base import RunContext, StepResult
 from exp_harness.utils import utc_now_iso, write_json, write_text
@@ -139,7 +140,7 @@ def _stream_process(
         for key, _ in events:
             _, file_fp, live_fp = key.data
             try:
-                chunk = os.read(key.fileobj.fileno(), 64 * 1024)
+                chunk = os.read(_selector_fd(key.fileobj), 64 * 1024)
             except Exception:
                 chunk = b""
             if not chunk:
@@ -157,3 +158,15 @@ def _stream_process(
     if killed:
         return 124
     return int(proc.returncode or 0)
+
+
+def _selector_fd(fileobj: object) -> int:
+    if isinstance(fileobj, int):
+        return fileobj
+    if hasattr(fileobj, "fileno"):
+        return cast(_HasFileno, fileobj).fileno()
+    raise TypeError("Selector file object does not provide fileno()")
+
+
+class _HasFileno(Protocol):
+    def fileno(self) -> int: ...

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.38.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a3/20aa7c4e83f2f614e0036300f3c352775dede0655c66814da16c37b661a9/basedpyright-1.38.2.tar.gz", hash = "sha256:b433b2b8ba745ed7520cdc79a29a03682f3fb00346d272ece5944e9e5e5daa92", size = 25277019, upload-time = "2026-02-26T11:18:43.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/12/736cab83626fea3fe65cdafb3ef3d2ee9480c56723f2fd33921537289a5e/basedpyright-1.38.2-py3-none-any.whl", hash = "sha256:153481d37fd19f9e3adedc8629d1d071b10c5f5e49321fb026b74444b7c70e24", size = 12312475, upload-time = "2026-02-26T11:18:40.373Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -136,6 +148,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -151,6 +164,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.31.0" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
@@ -212,6 +226,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/05/c75c0940b1ebf82975d14f37176679b6f3229eae8b47b6a70d1e1dae0723/nodejs_wheel_binaries-24.14.0.tar.gz", hash = "sha256:c87b515e44b0e4a523017d8c59f26ccbd05b54fe593338582825d4b51fc91e1c", size = 8057, upload-time = "2026-02-27T02:57:30.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/8c/b057c2db3551a6fe04e93dd14e33d810ac8907891534ffcc7a051b253858/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:59bb78b8eb08c3e32186da1ef913f1c806b5473d8bd0bb4492702092747b674a", size = 54798488, upload-time = "2026-02-27T02:56:56.831Z" },
+    { url = "https://files.pythonhosted.org/packages/30/88/7e1b29c067b6625c97c81eb8b0ef37cf5ad5b62bb81e23f4bde804910ec9/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:348fa061b57625de7250d608e2d9b7c4bc170544da7e328325343860eadd59e5", size = 54972803, upload-time = "2026-02-27T02:57:01.696Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/a83f0ff12faca2a56366462e572e38ac6f5cb361877bb29e289138eb7f24/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:222dbf516ccc877afcad4e4789a81b4ee93daaa9f0ad97c464417d9597f49449", size = 59340859, upload-time = "2026-02-27T02:57:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/06fad4ae8a723ae7096b5311eba67ad8b4df5f359c0a68e366750b7fef78/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b35d6fcccfe4fb0a409392d237fbc67796bac0d357b996bc12d057a1531a238b", size = 59838751, upload-time = "2026-02-27T02:57:10.449Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/72/4916dadc7307c3e9bcfa43b4b6f88237932d502c66f89eb2d90fb07810db/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:519507fb74f3f2b296ab1e9f00dcc211f36bbfb93c60229e72dcdee9dafd301a", size = 61340534, upload-time = "2026-02-27T02:57:15.309Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/a8ba881ee5d04b04e0d93abc8ce501ff7292813583e97f9789eb3fc0472a/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:68c93c52ff06d704bcb5ed160b4ba04ab1b291d238aaf996b03a5396e0e9a7ed", size = 61922394, upload-time = "2026-02-27T02:57:20.24Z" },
+    { url = "https://files.pythonhosted.org/packages/60/8c/b8c5f61201c72a0c7dc694b459941f89a6defda85deff258a9940a4e2efc/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:60b83c4e98b0c7d836ac9ccb67dcb36e343691cbe62cd325799ff9ed936286f3", size = 41218783, upload-time = "2026-02-27T02:57:24.175Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/1f904bc9cbd8eece393e20840c08ba3ac03440090c3a4e95168fa6d2709f/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:78a9bd1d6b11baf1433f9fb84962ff8aa71c87d48b6434f98224bc49a2253a6e", size = 38926103, upload-time = "2026-02-27T02:57:27.458Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `basedpyright` to dev dependencies and configure a practical baseline in `pyproject.toml`
- add a CI lint step to run `uv run basedpyright`
- document the type-check command in `README.md` and `CONTRIBUTING.md`
- fix small executor typing issues surfaced by the new checker (`selectors` fileobj fd handling + `executors.__all__` export warnings)

## Validation
- `uv run basedpyright`
- `uv run ruff check .`
- `uv run pytest -q`

Closes #2
