### PR TITLE
feat: add Python run API and delegate CLI run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ run-experiment locks gc [--grace-seconds 600] [--force] [--runs-root ...]
 
 `run-experiment run` streams step logs by default. Use `--no-follow-steps` to disable live streaming.
 
+## Python API
+
+```python
+from pathlib import Path
+
+from exp_harness.run.api import run_experiment
+
+result = run_experiment(
+    spec_path=Path("examples/toy.yaml"),
+    set_overrides=[("params.lr", "1e-4")],
+    runs_root=Path("experiment_results/runs"),
+    artifacts_root=Path("experiment_results/artifacts"),
+    follow_steps=False,
+)
+print(result["run_key"])
+```
+
 ## Overrides
 
 - `--set params.x=...` parses the RHS as YAML (so `3`, `true`, `[1,2]` work).

--- a/src/exp_harness/cli.py
+++ b/src/exp_harness/cli.py
@@ -7,21 +7,12 @@ from typing import Annotated, Any
 import typer
 
 from exp_harness.config import ENV_ARTIFACTS_ROOT, ENV_RUNS_ROOT, resolve_roots
-from exp_harness.utils import discover_project_root, discover_project_root_from_dir
+from exp_harness.run.api import OverrideParseError, parse_set_overrides
+from exp_harness.utils import discover_project_root_from_dir
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 locks_app = typer.Typer(no_args_is_help=True)
 app.add_typer(locks_app, name="locks")
-
-
-def _parse_set_kv(s: str) -> tuple[str, str]:
-    if "=" not in s:
-        raise typer.BadParameter("Expected KEY=VALUE")
-    k, v = s.split("=", 1)
-    k = k.strip()
-    if not k:
-        raise typer.BadParameter("Empty key")
-    return k, v
 
 
 @app.command()
@@ -81,21 +72,20 @@ def run(
     """
     Run a multi-step experiment from a YAML spec.
     """
-    from exp_harness.runner import run_experiment
+    from exp_harness.run.api import run_experiment
 
-    project_root = discover_project_root(spec)
-    roots = resolve_roots(
-        project_root=project_root, runs_root=runs_root, artifacts_root=artifacts_root
-    )
-
-    set_kv = [_parse_set_kv(x) for x in (set_ or [])]
-    set_str_kv = [_parse_set_kv(x) for x in (set_str or [])]
+    try:
+        set_kv = parse_set_overrides(set_ or [])
+        set_str_kv = parse_set_overrides(set_str or [])
+    except OverrideParseError as e:
+        raise typer.BadParameter(str(e)) from e
 
     res = run_experiment(
         spec_path=spec,
-        roots=roots,
         set_overrides=set_kv,
         set_string_overrides=set_str_kv,
+        runs_root=runs_root,
+        artifacts_root=artifacts_root,
         salt=salt,
         run_label=run_label,
         enforce_clean=enforce_clean,

--- a/src/exp_harness/run/__init__.py
+++ b/src/exp_harness/run/__init__.py
@@ -1,0 +1,3 @@
+from .api import OverrideParseError, RunResult, parse_set_overrides, run_experiment
+
+__all__ = ["OverrideParseError", "RunResult", "parse_set_overrides", "run_experiment"]

--- a/src/exp_harness/run/api.py
+++ b/src/exp_harness/run/api.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TypedDict, cast
+
+from exp_harness.config import resolve_roots
+from exp_harness.runner import run_experiment as _run_experiment
+from exp_harness.utils import discover_project_root
+
+
+class OverrideParseError(ValueError):
+    """Raised when a --set/--set-str assignment is not in KEY=VALUE form."""
+
+
+class RunResult(TypedDict):
+    name: str
+    run_id: str
+    run_key: str
+    run_dir: str
+    artifacts_dir: str
+
+
+def parse_set_overrides(values: Sequence[str]) -> list[tuple[str, str]]:
+    parsed: list[tuple[str, str]] = []
+    for value in values:
+        if "=" not in value:
+            raise OverrideParseError("Expected KEY=VALUE")
+        key, rhs = value.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise OverrideParseError("Empty key")
+        parsed.append((key, rhs))
+    return parsed
+
+
+def run_experiment(
+    *,
+    spec_path: Path,
+    set_overrides: Sequence[tuple[str, str]] | None = None,
+    set_string_overrides: Sequence[tuple[str, str]] | None = None,
+    runs_root: Path | None = None,
+    artifacts_root: Path | None = None,
+    salt: str | None = None,
+    run_label: str | None = None,
+    enforce_clean: bool = False,
+    follow_steps: bool = True,
+    stderr_tail_lines: int = 120,
+) -> RunResult:
+    project_root = discover_project_root(spec_path)
+    roots = resolve_roots(
+        project_root=project_root,
+        runs_root=runs_root,
+        artifacts_root=artifacts_root,
+    )
+    return cast(
+        RunResult,
+        _run_experiment(
+            spec_path=spec_path,
+            roots=roots,
+            set_overrides=list(set_overrides or []),
+            set_string_overrides=list(set_string_overrides or []),
+            salt=salt,
+            run_label=run_label,
+            enforce_clean=enforce_clean,
+            follow_steps=follow_steps,
+            stderr_tail_lines=stderr_tail_lines,
+        ),
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,7 +121,7 @@ def test_cli_run_defaults_follow_steps_true_and_allows_opt_out(tmp_path: Path, m
             "artifacts_dir": str(artifacts_root / "cli" / "abc123"),
         }
 
-    monkeypatch.setattr("exp_harness.runner.run_experiment", _fake_run_experiment)
+    monkeypatch.setattr("exp_harness.run.api.run_experiment", _fake_run_experiment)
 
     runner = CliRunner()
     res_default = runner.invoke(
@@ -181,7 +181,7 @@ def test_cli_passes_run_label_override(tmp_path: Path, monkeypatch) -> None:
             "artifacts_dir": str(artifacts_root / "cli" / "abc123"),
         }
 
-    monkeypatch.setattr("exp_harness.runner.run_experiment", _fake_run_experiment)
+    monkeypatch.setattr("exp_harness.run.api.run_experiment", _fake_run_experiment)
     runner = CliRunner()
     res = runner.invoke(
         app,

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from exp_harness.run.api import OverrideParseError, parse_set_overrides, run_experiment
+from tests.helpers import write_spec
+
+
+def test_parse_set_overrides_parses_key_value_pairs() -> None:
+    assert parse_set_overrides(["params.x=3", "params.y = abc"]) == [
+        ("params.x", "3"),
+        ("params.y", " abc"),
+    ]
+
+
+def test_parse_set_overrides_errors_on_invalid_assignments() -> None:
+    with pytest.raises(OverrideParseError, match="Expected KEY=VALUE"):
+        parse_set_overrides(["params.x"])
+    with pytest.raises(OverrideParseError, match="Empty key"):
+        parse_set_overrides(["=1"])
+
+
+def test_run_experiment_api_runs_spec_and_applies_overrides(tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    runs_root = tmp_path / "runs"
+    artifacts_root = tmp_path / "artifacts"
+    spec_fp = write_spec(
+        project_root,
+        {
+            "name": "api",
+            "env": {"kind": "local"},
+            "steps": [{"id": "a", "cmd": [sys.executable, "-c", "print('hi')"]}],
+        },
+    )
+
+    result = run_experiment(
+        spec_path=spec_fp,
+        set_overrides=[("params.x", "7")],
+        set_string_overrides=[("params.tag", "001")],
+        runs_root=runs_root,
+        artifacts_root=artifacts_root,
+        salt="from-api",
+        follow_steps=False,
+    )
+
+    run_dir = Path(result["run_dir"])
+    assert run_dir.exists()
+    run_json = json.loads((run_dir / "run.json").read_text(encoding="utf-8"))
+    assert run_json["state"] == "succeeded"
+
+    resolved = json.loads((run_dir / "resolved_spec.json").read_text(encoding="utf-8"))
+    assert resolved["params"]["x"] == 7
+    assert resolved["params"]["tag"] == "001"


### PR DESCRIPTION
## Summary
- add a public Python API module at `exp_harness.run.api` with:
  - `run_experiment(...)`
  - `parse_set_overrides(...)`
  - `OverrideParseError`
- refactor CLI `run` command to delegate execution through this API layer
- keep existing runner/provenance/executor behavior unchanged
- add dedicated API tests and update CLI monkeypatch targets
- document Python usage in `README.md`

## Validation
- `uv run ruff check .`
- `uv run basedpyright`
- `uv run pytest -q`

Closes #3
