### PR TITLE
feat: add hydra config composition and config groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ result = run_experiment(
 print(result["run_key"])
 ```
 
+Hydra composition API:
+
+```python
+from exp_harness.run.api import compose_experiment_config
+
+cfg = compose_experiment_config(
+    overrides=["env=docker", "resources=gpu1", "name=my_experiment"]
+)
+print(cfg["env"]["kind"])  # docker
+```
+
+The harness remains the source of truth for run directories/provenance; Hydra is used only for config
+composition and overrides.
+
 ## Overrides
 
 - `--set params.x=...` parses the RHS as YAML (so `3`, `true`, `[1,2]` work).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "A local experiments harness for reproducible multi-step runs."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+  "hydra-core>=1.3.2",
   "pydantic>=2.7",
   "pyyaml>=6.0",
   "typer>=0.12",

--- a/src/exp_harness/conf/__init__.py
+++ b/src/exp_harness/conf/__init__.py
@@ -1,0 +1,1 @@
+# Packaged Hydra config module for experiment composition.

--- a/src/exp_harness/conf/config.yaml
+++ b/src/exp_harness/conf/config.yaml
@@ -1,0 +1,13 @@
+defaults:
+  - env: local
+  - resources: default
+  - _self_
+
+name: default_experiment
+run_label: null
+inputs: {}
+vars: {}
+params: {}
+steps:
+  - id: main
+    cmd: ["python", "-c", "print('hello from hydra')"]

--- a/src/exp_harness/conf/env/docker.yaml
+++ b/src/exp_harness/conf/env/docker.yaml
@@ -1,0 +1,13 @@
+kind: docker
+workdir: /workspace
+env: {}
+offline: false
+docker:
+  image: python:3.12-slim
+  mounts: null
+  shm_size: null
+  ipc: private
+  network: bridge
+  runtime: null
+  gpu_mode: auto
+  allow_unverified_image: false

--- a/src/exp_harness/conf/env/local.yaml
+++ b/src/exp_harness/conf/env/local.yaml
@@ -1,0 +1,5 @@
+kind: local
+workdir: null
+env: {}
+offline: false
+docker: null

--- a/src/exp_harness/conf/resources/default.yaml
+++ b/src/exp_harness/conf/resources/default.yaml
@@ -1,0 +1,2 @@
+gpus: 0
+cpu: null

--- a/src/exp_harness/conf/resources/gpu1.yaml
+++ b/src/exp_harness/conf/resources/gpu1.yaml
@@ -1,0 +1,2 @@
+gpus: 1
+cpu: null

--- a/src/exp_harness/run/__init__.py
+++ b/src/exp_harness/run/__init__.py
@@ -1,3 +1,17 @@
-from .api import OverrideParseError, RunResult, parse_set_overrides, run_experiment
+from .api import (
+    ComposeConfigError,
+    OverrideParseError,
+    RunResult,
+    compose_experiment_config,
+    parse_set_overrides,
+    run_experiment,
+)
 
-__all__ = ["OverrideParseError", "RunResult", "parse_set_overrides", "run_experiment"]
+__all__ = [
+    "ComposeConfigError",
+    "OverrideParseError",
+    "RunResult",
+    "compose_experiment_config",
+    "parse_set_overrides",
+    "run_experiment",
+]

--- a/src/exp_harness/run/api.py
+++ b/src/exp_harness/run/api.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import Any, TypedDict, cast
+
+from hydra import compose, initialize_config_module
+from omegaconf import OmegaConf
 
 from exp_harness.config import resolve_roots
 from exp_harness.runner import run_experiment as _run_experiment
+from exp_harness.spec import ExperimentSpec
 from exp_harness.utils import discover_project_root
 
 
 class OverrideParseError(ValueError):
     """Raised when a --set/--set-str assignment is not in KEY=VALUE form."""
+
+
+class ComposeConfigError(ValueError):
+    """Raised when Hydra composition does not produce a valid experiment mapping."""
 
 
 class RunResult(TypedDict):
@@ -32,6 +40,25 @@ def parse_set_overrides(values: Sequence[str]) -> list[tuple[str, str]]:
             raise OverrideParseError("Empty key")
         parsed.append((key, rhs))
     return parsed
+
+
+def compose_experiment_config(
+    *,
+    overrides: Sequence[str] | None = None,
+    config_name: str = "config",
+    config_module: str = "exp_harness.conf",
+) -> dict[str, Any]:
+    with initialize_config_module(version_base=None, config_module=config_module):
+        cfg = compose(
+            config_name=config_name,
+            overrides=list(overrides or []),
+            return_hydra_config=False,
+        )
+    data = OmegaConf.to_container(cfg, resolve=True)
+    if not isinstance(data, dict):
+        raise ComposeConfigError("Hydra composition must produce a top-level mapping")
+    ExperimentSpec.model_validate(data)
+    return cast(dict[str, Any], data)
 
 
 def run_experiment(

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from exp_harness.run.api import OverrideParseError, parse_set_overrides, run_experiment
+from exp_harness.run.api import (
+    OverrideParseError,
+    compose_experiment_config,
+    parse_set_overrides,
+    run_experiment,
+)
 from tests.helpers import write_spec
 
 
@@ -22,6 +27,35 @@ def test_parse_set_overrides_errors_on_invalid_assignments() -> None:
         parse_set_overrides(["params.x"])
     with pytest.raises(OverrideParseError, match="Empty key"):
         parse_set_overrides(["=1"])
+
+
+def test_compose_experiment_config_defaults_are_valid() -> None:
+    cfg = compose_experiment_config()
+    assert cfg["name"] == "default_experiment"
+    assert cfg["env"]["kind"] == "local"
+    assert cfg["resources"]["gpus"] == 0
+    assert "hydra" not in cfg
+
+
+def test_compose_experiment_config_supports_group_overrides() -> None:
+    cfg = compose_experiment_config(overrides=["env=docker", "resources=gpu1", "name=hydra_demo"])
+    assert cfg["name"] == "hydra_demo"
+    assert cfg["env"]["kind"] == "docker"
+    assert cfg["resources"]["gpus"] == 1
+    assert cfg["env"]["docker"]["image"] == "python:3.12-slim"
+
+
+def test_compose_experiment_config_does_not_create_hydra_outputs(tmp_path: Path) -> None:
+    old_cwd = Path.cwd()
+    try:
+        import os
+
+        os.chdir(tmp_path)
+        _ = compose_experiment_config()
+    finally:
+        os.chdir(old_cwd)
+    assert not (tmp_path / "outputs").exists()
+    assert not (tmp_path / ".hydra").exists()
 
 
 def test_run_experiment_api_runs_spec_and_applies_overrides(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,12 @@ wheels = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "basedpyright"
 version = "1.38.2"
 source = { registry = "https://pypi.org/simple" }
@@ -141,6 +147,7 @@ name = "exp-harness"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "hydra-core" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -157,6 +164,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "hydra-core", specifier = ">=1.3.2" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.12" },
@@ -178,6 +186,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "hydra-core"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
 ]
 
 [[package]]
@@ -242,6 +264,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/df/a8ba881ee5d04b04e0d93abc8ce501ff7292813583e97f9789eb3fc0472a/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:68c93c52ff06d704bcb5ed160b4ba04ab1b291d238aaf996b03a5396e0e9a7ed", size = 61922394, upload-time = "2026-02-27T02:57:20.24Z" },
     { url = "https://files.pythonhosted.org/packages/60/8c/b8c5f61201c72a0c7dc694b459941f89a6defda85deff258a9940a4e2efc/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:60b83c4e98b0c7d836ac9ccb67dcb36e343691cbe62cd325799ff9ed936286f3", size = 41218783, upload-time = "2026-02-27T02:57:24.175Z" },
     { url = "https://files.pythonhosted.org/packages/91/23/1f904bc9cbd8eece393e20840c08ba3ac03440090c3a4e95168fa6d2709f/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:78a9bd1d6b11baf1433f9fb84962ff8aa71c87d48b6434f98224bc49a2253a6e", size = 38926103, upload-time = "2026-02-27T02:57:27.458Z" },
+]
+
+[[package]]
+name = "omegaconf"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `hydra-core` dependency
- add packaged Hydra config tree at `exp_harness.conf` with config groups:
  - `env`: `local`, `docker`
  - `resources`: `default`, `gpu1`
- add Python composition API in `exp_harness.run.api`:
  - `compose_experiment_config(...)`
  - `ComposeConfigError`
- validate composed output against canonical `ExperimentSpec`
- document Hydra composition usage in README
- add tests for:
  - default composition validity
  - config-group override behavior
  - no Hydra runtime output dirs (`outputs/`, `.hydra/`) from composition API

## Validation
- `uv run ruff check .`
- `uv run basedpyright`
- `uv run pytest -q`
- `uv build --wheel` (verified packaged YAML configs are included)

Closes #4
