### PR TITLE
feat: add hydra multirun sweep execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ run-experiment status [--name toy] [--limit 20] [--runs-root ...]
 run-experiment logs <name> <run_key> [--step train] [-f] [--runs-root ...]
 run-experiment inspect <name> <run_key> [--runs-root ...]
 run-experiment locks gc [--grace-seconds 600] [--force] [--runs-root ...]
+run-experiment sweep "name=myexp" "++params.lr=1e-3,1e-4" "resources=default,gpu1"
 ```
 
 `run-experiment run` streams step logs by default. Use `--no-follow-steps` to disable live streaming.
@@ -108,6 +109,17 @@ print(cfg["env"]["kind"])  # docker
 
 The harness remains the source of truth for run directories/provenance; Hydra is used only for config
 composition and overrides.
+
+Hydra sweep API:
+
+```python
+from exp_harness.run.api import run_hydra_sweep
+
+summary = run_hydra_sweep(
+    overrides=["name=myexp", "++params.lr=1e-3,1e-4", "resources=default,gpu1"],
+)
+print(summary["total"], summary["succeeded"], summary["failed"])
+```
 
 ## Overrides
 

--- a/src/exp_harness/cli.py
+++ b/src/exp_harness/cli.py
@@ -99,6 +99,88 @@ def run(
 
 
 @app.command()
+def sweep(
+    overrides: Annotated[
+        list[str] | None,
+        typer.Argument(
+            help="Hydra overrides; use comma-separated values for sweeps, e.g. ++params.lr=1e-3,1e-4",
+        ),
+    ] = None,
+    config_name: Annotated[
+        str,
+        typer.Option(
+            "--config-name",
+            help="Hydra config name from exp_harness.conf",
+        ),
+    ] = "config",
+    runs_root: Annotated[
+        Path | None,
+        typer.Option("--runs-root", help=f"Override runs root (env: {ENV_RUNS_ROOT})"),
+    ] = None,
+    artifacts_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--artifacts-root", help=f"Override artifacts root (env: {ENV_ARTIFACTS_ROOT})"
+        ),
+    ] = None,
+    salt: Annotated[
+        str | None, typer.Option("--salt", help="Run-key salt applied to all sweep members")
+    ] = None,
+    enforce_clean: Annotated[
+        bool, typer.Option("--enforce-clean", help="Fail if git working tree is dirty")
+    ] = False,
+    follow_steps: Annotated[
+        bool,
+        typer.Option(
+            "--follow-steps/--no-follow-steps",
+            "--follow/--no-follow",
+            help="Stream step stdout/stderr while running sweep members.",
+        ),
+    ] = False,
+    stderr_tail_lines: Annotated[
+        int,
+        typer.Option(
+            "--stderr-tail-lines",
+            help="On step failure, print the last N lines of stderr.log (0 disables).",
+        ),
+    ] = 120,
+) -> None:
+    """
+    Run a Hydra-backed parameter sweep through the canonical harness runner.
+    """
+    from exp_harness.run.api import run_hydra_sweep
+
+    result = run_hydra_sweep(
+        overrides=overrides or [],
+        config_name=config_name,
+        runs_root=runs_root,
+        artifacts_root=artifacts_root,
+        salt=salt,
+        enforce_clean=enforce_clean,
+        follow_steps=follow_steps,
+        stderr_tail_lines=stderr_tail_lines,
+        continue_on_error=True,
+    )
+
+    for item in result["runs"]:
+        idx = item["index"]
+        if item["status"] == "succeeded":
+            run_res = item["result"]
+            assert run_res is not None
+            typer.echo(f"[{idx}/{result['total']}] ok {run_res['name']} {run_res['run_key']}")
+        else:
+            over = " ".join(item["overrides"])
+            msg = item["error"] or "unknown error"
+            typer.echo(f"[{idx}/{result['total']}] failed ({over}): {msg}", err=True)
+
+    typer.echo(
+        f"sweep total={result['total']} succeeded={result['succeeded']} failed={result['failed']}"
+    )
+    if result["failed"] > 0:
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def status(
     name: Annotated[str | None, typer.Option("--name", help="Filter by experiment name")] = None,
     runs_root: Annotated[

--- a/src/exp_harness/run/__init__.py
+++ b/src/exp_harness/run/__init__.py
@@ -2,16 +2,24 @@ from .api import (
     ComposeConfigError,
     OverrideParseError,
     RunResult,
+    SweepMemberResult,
+    SweepResult,
     compose_experiment_config,
+    expand_hydra_sweep_overrides,
     parse_set_overrides,
     run_experiment,
+    run_hydra_sweep,
 )
 
 __all__ = [
     "ComposeConfigError",
     "OverrideParseError",
     "RunResult",
+    "SweepMemberResult",
+    "SweepResult",
     "compose_experiment_config",
+    "expand_hydra_sweep_overrides",
     "parse_set_overrides",
     "run_experiment",
+    "run_hydra_sweep",
 ]

--- a/src/exp_harness/run/api.py
+++ b/src/exp_harness/run/api.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
+from itertools import product
 from pathlib import Path
-from typing import Any, TypedDict, cast
+from tempfile import TemporaryDirectory
+from typing import Any, Literal, TypedDict, cast
 
+import yaml
 from hydra import compose, initialize_config_module
+from hydra.core.override_parser.overrides_parser import OverridesParser
 from omegaconf import OmegaConf
 
 from exp_harness.config import resolve_roots
 from exp_harness.runner import run_experiment as _run_experiment
 from exp_harness.spec import ExperimentSpec
-from exp_harness.utils import discover_project_root
+from exp_harness.utils import discover_project_root, discover_project_root_from_dir
 
 
 class OverrideParseError(ValueError):
@@ -29,6 +34,21 @@ class RunResult(TypedDict):
     artifacts_dir: str
 
 
+class SweepMemberResult(TypedDict):
+    index: int
+    overrides: list[str]
+    status: Literal["succeeded", "failed"]
+    result: RunResult | None
+    error: str | None
+
+
+class SweepResult(TypedDict):
+    total: int
+    succeeded: int
+    failed: int
+    runs: list[SweepMemberResult]
+
+
 def parse_set_overrides(values: Sequence[str]) -> list[tuple[str, str]]:
     parsed: list[tuple[str, str]] = []
     for value in values:
@@ -40,6 +60,29 @@ def parse_set_overrides(values: Sequence[str]) -> list[tuple[str, str]]:
             raise OverrideParseError("Empty key")
         parsed.append((key, rhs))
     return parsed
+
+
+def expand_hydra_sweep_overrides(overrides: Sequence[str] | None = None) -> list[list[str]]:
+    parser = OverridesParser.create()
+    parsed = parser.parse_overrides(list(overrides or []))
+
+    dimensions: list[list[str]] = []
+    for override in parsed:
+        if override.is_sweep_override():
+            key = override.get_key_element()
+            values = [
+                f"{key}={value}" for value in override.sweep_string_iterator() if value is not None
+            ]
+            dimensions.append(values)
+        else:
+            line = override.input_line
+            if line is None:
+                raise ComposeConfigError("Hydra override is missing input text")
+            dimensions.append([line])
+
+    if not dimensions:
+        return [[]]
+    return [list(combo) for combo in product(*dimensions)]
 
 
 def compose_experiment_config(
@@ -61,11 +104,89 @@ def compose_experiment_config(
     return cast(dict[str, Any], data)
 
 
+def run_hydra_sweep(
+    *,
+    overrides: Sequence[str] | None = None,
+    config_name: str = "config",
+    config_module: str = "exp_harness.conf",
+    project_root: Path | None = None,
+    runs_root: Path | None = None,
+    artifacts_root: Path | None = None,
+    salt: str | None = None,
+    enforce_clean: bool = False,
+    follow_steps: bool = False,
+    stderr_tail_lines: int = 120,
+    continue_on_error: bool = True,
+) -> SweepResult:
+    root = project_root or discover_project_root_from_dir(Path.cwd())
+    members = expand_hydra_sweep_overrides(overrides)
+    runs: list[SweepMemberResult] = []
+
+    with TemporaryDirectory(prefix="exp-harness-hydra-sweep-") as tmp_dir:
+        tmp_root = Path(tmp_dir)
+        for idx, member_overrides in enumerate(members, start=1):
+            try:
+                cfg = compose_experiment_config(
+                    overrides=member_overrides,
+                    config_name=config_name,
+                    config_module=config_module,
+                )
+                name = str(cfg.get("name") or "experiment")
+                safe_name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip("-._") or "experiment"
+                spec_path = tmp_root / f"{safe_name}__sweep_{idx:03d}.yaml"
+                spec_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+                run_res = run_experiment(
+                    spec_path=spec_path,
+                    set_overrides=[],
+                    set_string_overrides=[],
+                    project_root=root,
+                    runs_root=runs_root,
+                    artifacts_root=artifacts_root,
+                    salt=salt,
+                    run_label=f"sweep-{idx:03d}",
+                    enforce_clean=enforce_clean,
+                    follow_steps=follow_steps,
+                    stderr_tail_lines=stderr_tail_lines,
+                )
+                runs.append(
+                    {
+                        "index": idx,
+                        "overrides": list(member_overrides),
+                        "status": "succeeded",
+                        "result": run_res,
+                        "error": None,
+                    }
+                )
+            except Exception as exc:
+                runs.append(
+                    {
+                        "index": idx,
+                        "overrides": list(member_overrides),
+                        "status": "failed",
+                        "result": None,
+                        "error": str(exc),
+                    }
+                )
+                if not continue_on_error:
+                    break
+
+    succeeded = sum(1 for item in runs if item["status"] == "succeeded")
+    failed = len(runs) - succeeded
+    return {
+        "total": len(runs),
+        "succeeded": succeeded,
+        "failed": failed,
+        "runs": runs,
+    }
+
+
 def run_experiment(
     *,
     spec_path: Path,
     set_overrides: Sequence[tuple[str, str]] | None = None,
     set_string_overrides: Sequence[tuple[str, str]] | None = None,
+    project_root: Path | None = None,
     runs_root: Path | None = None,
     artifacts_root: Path | None = None,
     salt: str | None = None,
@@ -74,9 +195,9 @@ def run_experiment(
     follow_steps: bool = True,
     stderr_tail_lines: int = 120,
 ) -> RunResult:
-    project_root = discover_project_root(spec_path)
+    resolved_project_root = project_root or discover_project_root(spec_path)
     roots = resolve_roots(
-        project_root=project_root,
+        project_root=resolved_project_root,
         runs_root=runs_root,
         artifacts_root=artifacts_root,
     )

--- a/tests/test_cli_sweep.py
+++ b/tests/test_cli_sweep.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from exp_harness.cli import app
+
+
+def test_cli_sweep_success_exit_zero(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    runs_root = tmp_path / "runs"
+    artifacts_root = tmp_path / "artifacts"
+
+    def _fake_run_hydra_sweep(**kwargs):
+        return {
+            "total": 2,
+            "succeeded": 2,
+            "failed": 0,
+            "runs": [
+                {
+                    "index": 1,
+                    "overrides": ["name=sweep", "params.x=1"],
+                    "status": "succeeded",
+                    "result": {
+                        "name": "sweep",
+                        "run_id": "run-1",
+                        "run_key": "key-1",
+                        "run_dir": str(runs_root / "run-1"),
+                        "artifacts_dir": str(artifacts_root / "run-1"),
+                    },
+                    "error": None,
+                },
+                {
+                    "index": 2,
+                    "overrides": ["name=sweep", "params.x=2"],
+                    "status": "succeeded",
+                    "result": {
+                        "name": "sweep",
+                        "run_id": "run-2",
+                        "run_key": "key-2",
+                        "run_dir": str(runs_root / "run-2"),
+                        "artifacts_dir": str(artifacts_root / "run-2"),
+                    },
+                    "error": None,
+                },
+            ],
+        }
+
+    monkeypatch.setattr("exp_harness.run.api.run_hydra_sweep", _fake_run_hydra_sweep)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        runner = CliRunner()
+        res = runner.invoke(app, ["sweep", "name=sweep", "params.x=1,2"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert res.exit_code == 0, res.stdout + res.stderr
+    assert "sweep total=2 succeeded=2 failed=0" in res.stdout
+    assert "[1/2] ok sweep key-1" in res.stdout
+
+
+def test_cli_sweep_failure_exit_nonzero(monkeypatch, tmp_path: Path) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    def _fake_run_hydra_sweep(**kwargs):
+        return {
+            "total": 2,
+            "succeeded": 1,
+            "failed": 1,
+            "runs": [
+                {
+                    "index": 1,
+                    "overrides": ["name=sweep", "params.x=1"],
+                    "status": "succeeded",
+                    "result": {
+                        "name": "sweep",
+                        "run_id": "run-1",
+                        "run_key": "key-1",
+                        "run_dir": "/tmp/runs/run-1",
+                        "artifacts_dir": "/tmp/artifacts/run-1",
+                    },
+                    "error": None,
+                },
+                {
+                    "index": 2,
+                    "overrides": ["name=sweep", "params.x=2"],
+                    "status": "failed",
+                    "result": None,
+                    "error": "boom",
+                },
+            ],
+        }
+
+    monkeypatch.setattr("exp_harness.run.api.run_hydra_sweep", _fake_run_hydra_sweep)
+
+    import os
+
+    old_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        runner = CliRunner()
+        res = runner.invoke(app, ["sweep", "name=sweep", "params.x=1,2"])
+    finally:
+        os.chdir(old_cwd)
+
+    assert res.exit_code == 1
+    out = res.stdout + res.stderr
+    assert "[2/2] failed (name=sweep params.x=2): boom" in out
+    assert "sweep total=2 succeeded=1 failed=1" in out

--- a/tests/test_run_api.py
+++ b/tests/test_run_api.py
@@ -5,12 +5,15 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from exp_harness.run.api import (
     OverrideParseError,
     compose_experiment_config,
+    expand_hydra_sweep_overrides,
     parse_set_overrides,
     run_experiment,
+    run_hydra_sweep,
 )
 from tests.helpers import write_spec
 
@@ -56,6 +59,44 @@ def test_compose_experiment_config_does_not_create_hydra_outputs(tmp_path: Path)
         os.chdir(old_cwd)
     assert not (tmp_path / "outputs").exists()
     assert not (tmp_path / ".hydra").exists()
+
+
+def test_expand_hydra_sweep_overrides_builds_cartesian_product() -> None:
+    combos = expand_hydra_sweep_overrides(
+        ["name=demo", "params.lr=1e-3,1e-4", "resources=default,gpu1"]
+    )
+    assert len(combos) == 4
+    assert ["name=demo", "params.lr=0.001", "resources=default"] in combos
+    assert ["name=demo", "params.lr=0.0001", "resources=gpu1"] in combos
+
+
+def test_run_hydra_sweep_collects_partial_failures(tmp_path: Path, monkeypatch) -> None:
+    def _fake_run_experiment(**kwargs):
+        spec_path = Path(kwargs["spec_path"])
+        spec = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+        kind = str(spec.get("env", {}).get("kind"))
+        if kind == "docker":
+            raise RuntimeError("docker boom")
+        return {
+            "name": str(spec.get("name")),
+            "run_id": f"run-{kind}",
+            "run_key": f"key-{kind}",
+            "run_dir": str(tmp_path / "runs" / f"run-{kind}"),
+            "artifacts_dir": str(tmp_path / "artifacts" / f"run-{kind}"),
+        }
+
+    monkeypatch.setattr("exp_harness.run.api.run_experiment", _fake_run_experiment)
+    result = run_hydra_sweep(
+        overrides=["name=sweep_api", "env=local,docker"],
+        project_root=tmp_path,
+    )
+
+    assert result["total"] == 2
+    assert result["succeeded"] == 1
+    assert result["failed"] == 1
+    failed = [item for item in result["runs"] if item["status"] == "failed"]
+    assert len(failed) == 1
+    assert failed[0]["error"] == "docker boom"
 
 
 def test_run_experiment_api_runs_spec_and_applies_overrides(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add Hydra-backed sweep expansion and execution to the Python API:
  - `expand_hydra_sweep_overrides(...)`
  - `run_hydra_sweep(...)`
  - typed sweep result models (`SweepResult`, `SweepMemberResult`)
- execute each sweep member through the canonical harness run path (same runner/provenance model)
- add a new CLI entrypoint:
  - `run-experiment sweep ...`
- provide clear per-member status output and final summary (`total/succeeded/failed`)
- return non-zero CLI exit code when any sweep member fails, while still reporting partial successes
- add docs/examples for CLI and Python sweep usage

## Validation
- `uv run ruff check .`
- `uv run basedpyright`
- `uv run pytest -q`

Closes #5
